### PR TITLE
Import PropTypes

### DIFF
--- a/library/ImageViewer.js
+++ b/library/ImageViewer.js
@@ -4,7 +4,8 @@
 
 'use strict';
 
-import React, { Component,PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
     StyleSheet,
     View,

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "prop-types": "^15.6.0",
+  },
   "jest": {
     "preset": "jest-react-native"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "prop-types": "^15.6.0",
+    "prop-types": "^15.6.0"
   },
   "jest": {
     "preset": "jest-react-native"


### PR DESCRIPTION
This relates to a breaking change in React 16 where PropTypes were removed from React

> Warning: PropTypes has been moved to a separate package. Accessing React.PropTypes is no longer supported and will be removed completely in React 16. 